### PR TITLE
Re #1 - adds CI for image publish on main + tag

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,40 @@
+name: Tagged Releases
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - 'main'
+
+jobs:
+  publish-container-image:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Log into registry ghcr.io
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Registry Service
+      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        tags: ghcr.io/intersect-sdk/campaign-orchestrator:latest
+        push: true
+
+    - name: Push tagged images
+      if: startsWith(github.ref, 'refs/tags')
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        tags: |
+          ghcr.io/intersect-sdk/campaign-orchestrator:${{ github.ref_name }}
+        push: true


### PR DESCRIPTION
Work includes:
  - adding a simple GH Actions yaml to publish container images to GHCR
    - pretty much a copy-paste of https://github.com/INTERSECT-SDK/registry-service