### PR TITLE
Adds list campaigns w/ query for status

### DIFF
--- a/src/intersect_orchestrator/app/api/v1/endpoints/orchestrator/models/campaign_state.py
+++ b/src/intersect_orchestrator/app/api/v1/endpoints/orchestrator/models/campaign_state.py
@@ -50,6 +50,27 @@ class TaskState(Task):
     status: ExecutionStatus = ExecutionStatus.QUEUED
 
 
+# --- Response models for /campaigns endpoint ---
+
+from pydantic import BaseModel  # noqa: E402
+
+
+class CampaignInfo(BaseModel):
+    """Summary info for a single campaign in list responses."""
+
+    campaign_id: str
+    status: ExecutionStatus
+
+
+class CampaignListResponse(BaseModel):
+    """Response model for listing campaigns."""
+
+    campaigns: list[CampaignInfo]
+
+
+# --- End response models ---
+
+
 class TaskGroupState(TaskGroup):
     """Task group with execution state."""
 

--- a/src/intersect_orchestrator/app/api/v1/endpoints/orchestrator/routes.py
+++ b/src/intersect_orchestrator/app/api/v1/endpoints/orchestrator/routes.py
@@ -7,6 +7,7 @@ from fastapi import (
     APIRouter,
     Body,
     HTTPException,
+    Query,
     Request,
     Security,
     WebSocket,
@@ -20,8 +21,26 @@ from ...api_key import api_key_header
 if TYPE_CHECKING:
     from .....core.intersect_client import CoreServiceIntersectClient
 from .models.campaign import Campaign, IntersectCampaignId
+from .models.campaign_state import CampaignListResponse, ExecutionStatus
 
 router = APIRouter()
+
+
+@router.get(
+    '/campaigns',
+    description='List campaigns',
+    response_description='List of campaigns with their IDs and status',
+)
+async def list_campaigns(
+    request: Request,
+    api_key: Annotated[str, Security(api_key_header)],
+    status: Annotated[list[ExecutionStatus] | None, Query()] = None,
+) -> CampaignListResponse:
+    if api_key != settings.API_KEY:
+        raise HTTPException(status_code=401, detail='invalid or incorrect API key provided')
+    orchestrator = request.app.state.campaign_orchestrator
+    campaigns = orchestrator.list_campaigns(status=status)
+    return CampaignListResponse(campaigns=campaigns)
 
 
 @router.post(

--- a/src/intersect_orchestrator/app/core/campaign_orchestrator.py
+++ b/src/intersect_orchestrator/app/core/campaign_orchestrator.py
@@ -48,10 +48,11 @@ from ..api.v1.endpoints.orchestrator.models.campaign import (
     ObjectiveIterate,
 )
 from ..api.v1.endpoints.orchestrator.models.campaign_state import (
-    CampaignState as CampaignStateModel,
+    CampaignInfo,
+    ExecutionStatus,
 )
 from ..api.v1.endpoints.orchestrator.models.campaign_state import (
-    ExecutionStatus,
+    CampaignState as CampaignStateModel,
 )
 from ..converters.campaign_to_petri_net import CampaignPetriNetConverter
 from .objective_checkers import AssertChecker, IterateChecker, ObjectiveChecker
@@ -184,6 +185,32 @@ class CampaignOrchestrator:
             payload={'reason': 'Campaign cancelled by user'},
         )
         return True
+
+    def list_campaigns(self, status: list[ExecutionStatus] | None = None) -> list[CampaignInfo]:
+        """List campaigns, optionally filtered by status.
+
+        Args:
+            status: If provided, filter to only campaigns with this status.
+                   If None, return all campaigns (running only for now).
+
+        Returns:
+            List of CampaignInfo objects with campaign_id and status.
+        """
+        with self._lock:
+            # Currently we only track running campaigns in memory
+            campaigns = []
+            for _campaign_id, state in self._campaigns.items():
+                campaign_status = ExecutionStatus.RUNNING
+                # Filter by status if provided
+                if status is not None and campaign_status not in status:
+                    continue
+                campaigns.append(
+                    CampaignInfo(
+                        campaign_id=str(state.campaign.id),
+                        status=campaign_status,
+                    )
+                )
+            return campaigns
 
     def get_campaign(self, campaign_id: IntersectCampaignId) -> Campaign | None:
         """Get a campaign payload from memory."""

--- a/tests/unit/app/api/v1/endpoints/orchestrator/test_routes.py
+++ b/tests/unit/app/api/v1/endpoints/orchestrator/test_routes.py
@@ -178,3 +178,93 @@ def test_stop_campaign_invalid_uuid(client, valid_api_key):
 
     # Should fail validation due to UUID format
     assert response.status_code == 422  # Validation error
+
+
+# --- Tests for GET /campaigns endpoint ---
+
+
+def test_get_campaigns_empty(client, valid_api_key):
+    """Test getting campaigns when none are running."""
+    response = client.get(
+        '/v1/orchestrator/campaigns',
+        headers={'Authorization': valid_api_key},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert 'campaigns' in data
+    assert data['campaigns'] == []
+
+
+def test_get_campaigns_with_running_filter(client, valid_api_key, sample_campaign_data):
+    """Test getting only running campaigns with status filter."""
+    # Start a campaign first
+    start_response = client.post(
+        '/v1/orchestrator/start_campaign',
+        json=sample_campaign_data,
+        headers={'Authorization': valid_api_key},
+    )
+    assert start_response.status_code == 200
+
+    # Get running campaigns
+    response = client.get(
+        '/v1/orchestrator/campaigns',
+        params={'status': 'running'},
+        headers={'Authorization': valid_api_key},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert 'campaigns' in data
+    # Each campaign entry should have campaign_id and status
+    for campaign in data['campaigns']:
+        assert 'campaign_id' in campaign
+        assert 'status' in campaign
+        # Validate campaign_id is a valid UUID
+        uuid.UUID(campaign['campaign_id'])
+
+
+def test_get_campaigns_returns_campaign_id_and_status(client, valid_api_key, sample_campaign_data):
+    """Test that campaign entries include campaign_id and status fields."""
+    # Start a campaign
+    start_response = client.post(
+        '/v1/orchestrator/start_campaign',
+        json=sample_campaign_data,
+        headers={'Authorization': valid_api_key},
+    )
+    assert start_response.status_code == 200
+
+    # Get all campaigns
+    response = client.get(
+        '/v1/orchestrator/campaigns',
+        headers={'Authorization': valid_api_key},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data['campaigns']) >= 1
+
+    # Verify structure of each campaign entry
+    campaign_entry = data['campaigns'][0]
+    assert 'campaign_id' in campaign_entry
+    assert 'status' in campaign_entry
+    # campaign_id should match the one from the campaign data
+    assert campaign_entry['campaign_id'] == sample_campaign_data['id']
+
+
+def test_get_campaigns_invalid_api_key(client, invalid_api_key):
+    """Test getting campaigns with invalid API key."""
+    response = client.get(
+        '/v1/orchestrator/campaigns',
+        headers={'Authorization': invalid_api_key},
+    )
+
+    assert response.status_code == 401
+    assert 'invalid or incorrect API key provided' in response.json()['detail']
+
+
+def test_get_campaigns_missing_api_key(client):
+    """Test getting campaigns without API key."""
+    response = client.get('/v1/orchestrator/campaigns')
+
+    assert response.status_code == 403  # FastAPI's default for missing security dependency


### PR DESCRIPTION
Re #27 but does not close that issue

Work includes:
  - adds list campaigns to campaign orchestrator business logic
  - adds endpoint /campaigns with GET to get the list of campaigns w/ status
  - can query via `/campaigns?status=running&status=queued`
      - uses ExecutionStatus with options 'queued', 'running', 'complete', 'error'