### PR TITLE
New task event modes (listen for one event, N events, or indefinitely) + unique queue names for campaign orchestrators

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,23 @@
-# ignore everything by default
+.git
+.github
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+build
+dist
+docs/_build
+htmlcov
+.coverage
+concepts
+services
+tests
+README.md
+AGENTS.md# ignore everything by default
 *
 # but do not ignore core files
 !src/

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -3,113 +3,120 @@ name: Tagged Releases
 on:
   push:
     tags:
-      - '*'
+      - "*"
     branches:
-      - 'main'
+      - "main"
 
 jobs:
   publish-container-image:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
-    - name: Log into registry ghcr.io
-      uses: docker/login-action@v4
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log into registry ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-    - name: Build base orchestrator image (smoke test)
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        target: runner
-        platforms: linux/amd64
-        tags: campaign-orchestrator-base:ci
-        load: true
-        push: false
+      - name: Build base orchestrator image (smoke test)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            EXTRA_BUILD_ARGS=
+          tags: campaign-orchestrator-base:ci
+          load: true
+          push: false
 
-    - name: Build full orchestrator image (smoke test)
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        target: full
-        platforms: linux/amd64
-        tags: campaign-orchestrator-full:ci
-        load: true
-        push: false
+      - name: Build full orchestrator image (smoke test)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            EXTRA_BUILD_ARGS="--all-extras"
+          tags: campaign-orchestrator-full:ci
+          load: true
+          push: false
 
-    - name: Smoke test orchestrator image targets
-      run: |
-        docker run --rm campaign-orchestrator-base:ci python -c "import intersect_orchestrator"
-        docker run --rm campaign-orchestrator-full:ci python -c "import intersect_orchestrator, pymongo, psycopg"
+      - name: Smoke test orchestrator image targets
+        # first test ensures that the base image does NOT have the extra dependencies
+        run: |
+          docker run --rm campaign-orchestrator-base:ci python -c $'import intersect_orchestrator\ntry:\n  import pymongo\n  exit(1)\nexcept ImportError:\n  pass\ntry:\n  import psycopg\n  exit(1)\nexcept ImportError:\n  pass'
+          docker run --rm campaign-orchestrator-full:ci python -c "import intersect_orchestrator, pymongo, psycopg"
 
-    - name: Build and push Orchestrator
-      if: ${{ github.ref == 'refs/heads/main' }}
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        target: runner
-        platforms: linux/amd64,linux/arm64
-        tags: ghcr.io/intersect-sdk/campaign-orchestrator:latest
-        push: true
+      - name: Build and push Orchestrator
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            EXTRA_BUILD_ARGS=
+          tags: ghcr.io/intersect-sdk/campaign-orchestrator:latest
+          push: true
 
-    - name: Push tagged images
-      if: startsWith(github.ref, 'refs/tags')
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        target: runner
-        platforms: linux/amd64,linux/arm64
-        tags: |
-          ghcr.io/intersect-sdk/campaign-orchestrator:${{ github.ref_name }}
-        push: true
+      - name: Push tagged images
+        if: startsWith(github.ref, 'refs/tags')
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            EXTRA_BUILD_ARGS=
+          tags: |
+            ghcr.io/intersect-sdk/campaign-orchestrator:${{ github.ref_name }}
+          push: true
 
-    - name: Build and push Orchestrator Full Backends (latest)
-      if: ${{ github.ref == 'refs/heads/main' }}
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        target: full
-        platforms: linux/amd64,linux/arm64
-        tags: ghcr.io/intersect-sdk/campaign-orchestrator-backends-full:latest
-        push: true
+      - name: Build and push Orchestrator Full Backends (latest)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            EXTRA_BUILD_ARGS="--all-extras"
+          tags: ghcr.io/intersect-sdk/campaign-orchestrator-backends-full:latest
+          push: true
 
-    - name: Push tagged Orchestrator Full Backends images
-      if: startsWith(github.ref, 'refs/tags')
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        target: full
-        platforms: linux/amd64,linux/arm64
-        tags: |
-          ghcr.io/intersect-sdk/campaign-orchestrator-backends-full:${{ github.ref_name }}
-        push: true
+      - name: Push tagged Orchestrator Full Backends images
+        if: startsWith(github.ref, 'refs/tags')
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            EXTRA_BUILD_ARGS="--all-extras"
+          tags: |
+            ghcr.io/intersect-sdk/campaign-orchestrator-backends-full:${{ github.ref_name }}
+          push: true
 
-    - name: Build and push Random Number Service (latest)
-      if: ${{ github.ref == 'refs/heads/main' }}
-      uses: docker/build-push-action@v7
-      with:
-        context: ./services/random_number_service
-        platforms: linux/amd64,linux/arm64
-        tags: ghcr.io/intersect-sdk/campaign-orchestrator/random-number-service:latest
-        push: true
+      - name: Build and push Random Number Service (latest)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: ./services/random_number_service
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/intersect-sdk/campaign-orchestrator/random-number-service:latest
+          push: true
 
-    - name: Push tagged Random Number Service
-      if: startsWith(github.ref, 'refs/tags')
-      uses: docker/build-push-action@v7
-      with:
-        context: ./services/random_number_service
-        platforms: linux/amd64,linux/arm64
-        tags: |
-          ghcr.io/intersect-sdk/campaign-orchestrator/random-number-service:${{ github.ref_name }}
-        push: true
+      - name: Push tagged Random Number Service
+        if: startsWith(github.ref, 'refs/tags')
+        uses: docker/build-push-action@v7
+        with:
+          context: ./services/random_number_service
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/intersect-sdk/campaign-orchestrator/random-number-service:${{ github.ref_name }}
+          push: true

--- a/.github/workflows/full-test-suite.yaml
+++ b/.github/workflows/full-test-suite.yaml
@@ -2,17 +2,17 @@ name: Full Test Suite
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   push:
-    branches: [ '**' ]
+    branches: ["**"]
     paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'services/**'
-      - 'docker-compose.yml'
-      - 'Dockerfile'
-      - 'pyproject.toml'
-      - '.github/workflows/full-test-suite.yaml'
+      - "src/**"
+      - "tests/**"
+      - "services/**"
+      - "docker-compose.yml"
+      - "Dockerfile"
+      - "pyproject.toml"
+      - ".github/workflows/full-test-suite.yaml"
   workflow_dispatch:
 
 concurrency:
@@ -26,18 +26,14 @@ jobs:
   docker-image-targets:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-    - name: Build base orchestrator image target
-      run: docker build --target runner -t campaign-orchestrator-base:test .
+      - name: Build full orchestrator image target
+        run: docker build --build-arg EXTRA_BUILD_ARGS='--all-extras' -t campaign-orchestrator-full:test .
 
-    - name: Build full orchestrator image target
-      run: docker build --target full -t campaign-orchestrator-full:test .
-
-    - name: Test base and full image dependencies
-      run: |
-        docker run --rm campaign-orchestrator-base:test python -c "import intersect_orchestrator"
-        docker run --rm campaign-orchestrator-full:test python -c "import intersect_orchestrator, pymongo, psycopg"
+      - name: Test full image dependencies
+        run: |
+          docker run --rm campaign-orchestrator-full:test python -c "import intersect_orchestrator, pymongo, psycopg"
 
   full-tests:
     runs-on: ubuntu-latest
@@ -83,122 +79,121 @@ jobs:
           --health-retries=5
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.13'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v3
-      with:
-        version: "latest"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
 
-    - name: Install system dependencies
-      run: sudo apt-get update && sudo apt-get install -y libpq-dev
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev
 
-    - name: Install dependencies with DB extras
-      run: uv sync --dev --extra mongo --extra postgres
+      - name: Install dependencies with DB extras
+        run: uv sync --dev --extra mongo --extra postgres
 
-    - name: Build and start random-number-service
-      run: |
-        docker build -t random-number-service ./services/random_number_service/
-        docker run -d --name rng-service \
-          --network host \
-          -e BROKER_HOST=localhost \
-          -e BROKER_PORT=5672 \
-          -e BROKER_USERNAME=intersect_username \
-          -e BROKER_PASSWORD=intersect_password \
-          -e BROKER_PROTOCOL=amqp0.9.1 \
-          random-number-service
-        # Give the service time to connect to the broker
-        sleep 15
+      - name: Build and start random-number-service
+        run: |
+          docker build -t random-number-service ./services/random_number_service/
+          docker run -d --name rng-service \
+            --network host \
+            -e BROKER_HOST=localhost \
+            -e BROKER_PORT=5672 \
+            -e BROKER_USERNAME=intersect_username \
+            -e BROKER_PASSWORD=intersect_password \
+            -e BROKER_PROTOCOL=amqp0.9.1 \
+            random-number-service
+          # Give the service time to connect to the broker
+          sleep 15
 
-    - name: Run integration tests with coverage
-      env:
-        BROKER_HOST: localhost
-        BROKER_PORT: 5672
-        BROKER_USERNAME: intersect_username
-        BROKER_PASSWORD: intersect_password
-        BROKER_PROTOCOL: amqp0.9.1
-        CAMPAIGN_REPOSITORY_MONGO_URI: mongodb://intersect:intersect@localhost:27017
-        CAMPAIGN_REPOSITORY_MONGO_DB: intersect_orchestrator
-        CAMPAIGN_REPOSITORY_POSTGRES_DSN: postgresql://intersect:intersect@localhost:5432/intersect_orchestrator
-        RANDOM_NUMBER_SERVICE_AVAILABLE: "true"
-      run: uv run pytest tests/integration --cov=intersect_orchestrator --cov-report=term-missing --cov-report=html
+      - name: Run integration tests with coverage
+        env:
+          BROKER_HOST: localhost
+          BROKER_PORT: 5672
+          BROKER_USERNAME: intersect_username
+          BROKER_PASSWORD: intersect_password
+          BROKER_PROTOCOL: amqp0.9.1
+          CAMPAIGN_REPOSITORY_MONGO_URI: mongodb://intersect:intersect@localhost:27017
+          CAMPAIGN_REPOSITORY_MONGO_DB: intersect_orchestrator
+          CAMPAIGN_REPOSITORY_POSTGRES_DSN: postgresql://intersect:intersect@localhost:5432/intersect_orchestrator
+          RANDOM_NUMBER_SERVICE_AVAILABLE: "true"
+        run: uv run pytest tests/integration --cov=intersect_orchestrator --cov-report=term-missing --cov-report=html
 
-    - name: Upload coverage HTML report
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: coverage-report
-        path: htmlcov/
-
+      - name: Upload coverage HTML report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: htmlcov/
 
   full-tests-docker-compose:
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: docker-image-targets
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.13'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v3
-      with:
-        version: "latest"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
 
-    - name: Install system dependencies
-      run: sudo apt-get update && sudo apt-get install -y libpq-dev
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev
 
-    - name: Install dependencies with DB extras
-      run: uv sync --dev --extra mongo --extra postgres
+      - name: Install dependencies with DB extras
+        run: uv sync --dev --extra mongo --extra postgres
 
-    - name: Start services with docker-compose
-      run: docker compose up -d
+      - name: Start services with docker-compose
+        run: docker compose up -d
 
-    - name: Wait for services to be healthy
-      run: |
-        # Wait specifically for the orchestrator to become healthy.
-        # The orchestrator depends on broker + mongo + postgres being healthy
-        # before it starts, so waiting for it implies all backing services are
-        # ready.  The random-number-service also starts after the broker is
-        # healthy, so it will be connected before the orchestrator finishes its
-        # own startup sequence.
-        timeout 120 bash -c 'until docker compose ps | grep -w orchestrator | grep -q "(healthy)"; do sleep 2; done'
-        docker compose ps
+      - name: Wait for services to be healthy
+        run: |
+          # Wait specifically for the orchestrator to become healthy.
+          # The orchestrator depends on broker + mongo + postgres being healthy
+          # before it starts, so waiting for it implies all backing services are
+          # ready.  The random-number-service also starts after the broker is
+          # healthy, so it will be connected before the orchestrator finishes its
+          # own startup sequence.
+          timeout 120 bash -c 'until docker compose ps | grep -w orchestrator | grep -q "(healthy)"; do sleep 2; done'
+          docker compose ps
 
-    - name: Run integration tests with coverage
-      env:
-        API_KEY: test-api-key-12345678901234567890
-        BROKER_HOST: localhost
-        BROKER_PORT: 5672
-        BROKER_USERNAME: intersect_username
-        BROKER_PASSWORD: intersect_password
-        BROKER_PROTOCOL: amqp0.9.1
-        CAMPAIGN_REPOSITORY_MONGO_URI: mongodb://intersect:intersect@localhost:27017
-        CAMPAIGN_REPOSITORY_MONGO_DB: intersect_orchestrator
-        CAMPAIGN_REPOSITORY_POSTGRES_DSN: postgresql://intersect:intersect@localhost:5432/intersect_orchestrator
-        ORCHESTRATOR_HOST: localhost
-        ORCHESTRATOR_PORT: 8000
-      run: uv run pytest tests/integration --cov=intersect_orchestrator --cov-report=term-missing --cov-report=html
+      - name: Run integration tests with coverage
+        env:
+          API_KEY: test-api-key-12345678901234567890
+          BROKER_HOST: localhost
+          BROKER_PORT: 5672
+          BROKER_USERNAME: intersect_username
+          BROKER_PASSWORD: intersect_password
+          BROKER_PROTOCOL: amqp0.9.1
+          CAMPAIGN_REPOSITORY_MONGO_URI: mongodb://intersect:intersect@localhost:27017
+          CAMPAIGN_REPOSITORY_MONGO_DB: intersect_orchestrator
+          CAMPAIGN_REPOSITORY_POSTGRES_DSN: postgresql://intersect:intersect@localhost:5432/intersect_orchestrator
+          ORCHESTRATOR_HOST: localhost
+          ORCHESTRATOR_PORT: 8000
+        run: uv run pytest tests/integration --cov=intersect_orchestrator --cov-report=term-missing --cov-report=html
 
-    - name: Show docker-compose logs on failure
-      if: failure()
-      run: docker compose logs
+      - name: Show docker-compose logs on failure
+        if: failure()
+        run: docker compose logs
 
-    - name: Cleanup docker-compose
-      if: always()
-      run: docker compose down -v
+      - name: Cleanup docker-compose
+        if: always()
+        run: docker compose down -v
 
-    - name: Upload coverage HTML report
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: coverage-report-docker-compose
-        path: htmlcov/
+      - name: Upload coverage HTML report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report-docker-compose
+          path: htmlcov/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,60 +1,38 @@
-# see https://docs.astral.sh/uv/guides/integration/docker/#optimizations and https://www.joshkasuboski.com/posts/distroless-python-uv/
+FROM python:3.13-slim AS base
 
-FROM ghcr.io/astral-sh/uv:debian-slim AS builder
-
-ARG PYTHON_VERSION=3.13
-# set to "0" to include dev dependencies, "1" to exclude them (default: "1")
-ARG UV_NO_DEV="1"
-
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
-ENV UV_PYTHON_INSTALL_DIR=/python
-ENV UV_PYTHON_PREFERENCE=only-managed
-ENV UV_NO_DEV=${UV_NO_DEV}
-
-RUN uv python install ${PYTHON_VERSION}
 
 WORKDIR /app
 
-# Install required dependencies only for the base image target.
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project --no-editable
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Sync the project for the base image target.
-COPY src src
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-editable
+COPY pyproject.toml uv.lock /app/
+COPY src /app/src
 
-# Full dependency builder includes optional repository drivers for mongo + postgres.
-FROM builder AS builder-full
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-editable --extra mongo --extra postgres
+FROM base AS builder
 
-FROM gcr.io/distroless/cc:nonroot AS runner
+RUN uv sync --locked --no-editable
 
-COPY --from=builder --chown=python:python /python /python
+FROM base AS builder-full
+
+RUN uv sync --locked --no-editable --extra mongo --extra postgres
+
+FROM python:3.13-slim AS runner
 
 WORKDIR /app
-COPY --from=builder --chown=app:app /app/.venv /app/.venv
+COPY --from=builder /app/.venv /app/.venv
 
 ENV PATH="/app/.venv/bin:$PATH"
 
-# override CMD at container runtime for tests
-# note that you generally will NOT want to set UVICORN_WORKERS if running in a Kubernetes cluster, let Kubernetes handle that for you
 CMD ["python", "-m", "intersect_orchestrator"]
 
-FROM gcr.io/distroless/cc:nonroot AS full
-
-COPY --from=builder-full --chown=python:python /python /python
+FROM python:3.13-slim AS full
 
 WORKDIR /app
-COPY --from=builder-full --chown=app:app /app/.venv /app/.venv
+COPY --from=builder-full /app/.venv /app/.venv
 
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,20 @@ WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 COPY pyproject.toml uv.lock /app/
-COPY src /app/src
 
 FROM base AS builder
+
+RUN uv sync --locked --no-editable --no-install-project
+
+COPY src /app/src
 
 RUN uv sync --locked --no-editable
 
 FROM base AS builder-full
+
+RUN uv sync --locked --no-editable --extra mongo --extra postgres --no-install-project
+
+COPY src /app/src
 
 RUN uv sync --locked --no-editable --extra mongo --extra postgres
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,29 +4,31 @@
 FROM ghcr.io/astral-sh/uv:debian-slim AS builder
 
 ARG PYTHON_VERSION=3.13
+# set UV_NO_DEV to empty string if you want to include the "dev" group in dependency-groups
+ARG UV_NO_DEV="1"
+# any extra groups to include with the image - use empty string if you want no extra groups
+ARG EXTRA_BUILD_ARGS="--extra mongo --extra postgres"
 
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/python
 ENV UV_PYTHON_PREFERENCE=only-managed
+ENV UV_NO_DEV=${UV_NO_DEV}
 
 RUN uv python install ${PYTHON_VERSION}
 
 WORKDIR /app
 
 # Copy dependency files
+# NOTE: cannot use --mount syntax because we want to keep this build compatible for systems without buildx
 COPY pyproject.toml uv.lock ./
 
 # Install dependencies (without project itself)
-RUN uv sync --locked --no-install-project --no-editable
+RUN eval "uv sync --locked --no-install-project --no-editable $EXTRA_BUILD_ARGS"
 
 # Copy source and install project
 COPY src src
-RUN uv sync --locked --no-editable
-
-# Full dependency builder includes optional repository drivers for mongo + postgres.
-FROM builder AS builder-full
-RUN uv sync --locked --no-editable --extra mongo --extra postgres
+RUN eval "uv sync --locked --no-editable $EXTRA_BUILD_ARGS"
 
 # Use distroless for minimal image size (no shell, no package manager)
 # For debugging, change to gcr.io/distroless/cc:nonroot-debug (includes busybox shell)
@@ -36,17 +38,6 @@ COPY --from=builder /python /python
 
 WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
-
-ENV PATH="/app/.venv/bin:$PATH"
-
-CMD ["python", "-m", "intersect_orchestrator"]
-
-FROM gcr.io/distroless/cc:nonroot AS full
-
-COPY --from=builder-full /python /python
-
-WORKDIR /app
-COPY --from=builder-full /app/.venv /app/.venv
 
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,38 @@
-FROM python:3.13-slim AS base
+# see https://docs.astral.sh/uv/guides/integration/docker/#optimizations and https://www.joshkasuboski.com/posts/distroless-python-uv/
+# Modified to work without BuildKit (no --mount syntax)
 
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
+FROM ghcr.io/astral-sh/uv:debian-slim AS builder
+
+ARG PYTHON_VERSION=3.13
+
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+
+RUN uv python install ${PYTHON_VERSION}
 
 WORKDIR /app
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
 
-COPY pyproject.toml uv.lock /app/
+# Install dependencies (without project itself)
+RUN uv sync --locked --no-install-project --no-editable
 
-FROM base AS builder
-
-RUN uv sync --locked --no-editable --no-install-project
-
-COPY src /app/src
-
+# Copy source and install project
+COPY src src
 RUN uv sync --locked --no-editable
 
-FROM base AS builder-full
-
-RUN uv sync --locked --no-editable --extra mongo --extra postgres --no-install-project
-
-COPY src /app/src
-
+# Full dependency builder includes optional repository drivers for mongo + postgres.
+FROM builder AS builder-full
 RUN uv sync --locked --no-editable --extra mongo --extra postgres
 
-FROM python:3.13-slim AS runner
+# Use distroless for minimal image size (no shell, no package manager)
+# For debugging, change to gcr.io/distroless/cc:nonroot-debug (includes busybox shell)
+FROM gcr.io/distroless/cc:nonroot AS runner
+
+COPY --from=builder /python /python
 
 WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
@@ -36,7 +41,9 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 CMD ["python", "-m", "intersect_orchestrator"]
 
-FROM python:3.13-slim AS full
+FROM gcr.io/distroless/cc:nonroot AS full
+
+COPY --from=builder-full /python /python
 
 WORKDIR /app
 COPY --from=builder-full /app/.venv /app/.venv

--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ Make sure you have UV installed ([Instructions](https://docs.astral.sh/uv/#insta
 - `docker compose up -d` - configures a message broker setup if you don't already have one
 - `uv run python -m intersect_orchestrator`
 
+### Running unit tests
+
+Run unit tests without external dependencies:
+
+```bash
+uv run pytest tests/unit -p no:postgresql
+```
+
+To run with all optional dependencies (MongoDB, PostgreSQL):
+
+```bash
+uv sync --dev --extra mongo --extra postgres
+uv run pytest tests/unit --cov=intersect_orchestrator --cov-report=term-missing
+```
+
 ## Published container images
 
 - `ghcr.io/intersect-sdk/campaign-orchestrator:latest` - base image (no optional DB drivers)

--- a/src/intersect_orchestrator/app/api/v1/endpoints/orchestrator/models/campaign.py
+++ b/src/intersect_orchestrator/app/api/v1/endpoints/orchestrator/models/campaign.py
@@ -212,6 +212,15 @@ class Task(BaseModel):
 
     Each event name has an output schema. Event names are namespaced to Capabilities.
     """
+    event_mode: Literal['once', 'count', 'persistent'] = 'once'
+    """How an event task consumes matching events.
+
+    once: complete permanently after the first matching event.
+    count: complete after ``event_count`` matching events.
+    persistent: reactivate after each matching event and remain open.
+    """
+    event_count: int | None = None
+    """Required positive count when ``event_mode`` is ``count``; otherwise must be omitted."""
     output: Output | None = None
     input: Input | None = None
     task_dependencies: Annotated[list[uuid.UUID], Field(default_factory=list)]
@@ -226,6 +235,25 @@ class Task(BaseModel):
         if bool(self.event_name) == bool(self.operation_id):
             errors.append(
                 f'Task {self.id} needs to define exactly one of operation_id or event_name'
+            )
+
+        if self.event_name is None:
+            if self.event_mode != 'once':
+                errors.append(
+                    f'Task {self.id} cannot define event_mode unless event_name is set'
+                )
+            if self.event_count is not None:
+                errors.append(
+                    f'Task {self.id} cannot define event_count unless event_name is set'
+                )
+        elif self.event_mode == 'count':
+            if self.event_count is None or self.event_count <= 0:
+                errors.append(
+                    f'Task {self.id} with event_mode=count must define a positive event_count'
+                )
+        elif self.event_count is not None:
+            errors.append(
+                f'Task {self.id} can only define event_count when event_mode=count'
             )
 
         if errors:

--- a/src/intersect_orchestrator/app/api/v1/endpoints/orchestrator/models/campaign.py
+++ b/src/intersect_orchestrator/app/api/v1/endpoints/orchestrator/models/campaign.py
@@ -239,22 +239,16 @@ class Task(BaseModel):
 
         if self.event_name is None:
             if self.event_mode != 'once':
-                errors.append(
-                    f'Task {self.id} cannot define event_mode unless event_name is set'
-                )
+                errors.append(f'Task {self.id} cannot define event_mode unless event_name is set')
             if self.event_count is not None:
-                errors.append(
-                    f'Task {self.id} cannot define event_count unless event_name is set'
-                )
+                errors.append(f'Task {self.id} cannot define event_count unless event_name is set')
         elif self.event_mode == 'count':
             if self.event_count is None or self.event_count <= 0:
                 errors.append(
                     f'Task {self.id} with event_mode=count must define a positive event_count'
                 )
         elif self.event_count is not None:
-            errors.append(
-                f'Task {self.id} can only define event_count when event_mode=count'
-            )
+            errors.append(f'Task {self.id} can only define event_count when event_mode=count')
 
         if errors:
             raise ValueError('\n'.join(errors))

--- a/src/intersect_orchestrator/app/core/campaign_orchestrator.py
+++ b/src/intersect_orchestrator/app/core/campaign_orchestrator.py
@@ -142,7 +142,9 @@ class CampaignOrchestrator:
         self._lock = threading.Lock()
         self._campaigns: dict[IntersectCampaignId, CampaignState] = {}
         self._campaign_petri_nets: dict[IntersectCampaignId, PetriNet] = {}
-        logger.info('Orchestrator initialized with hierarchy: %s', self._client.get_orchestrator_hierarchy())
+        logger.info(
+            'Orchestrator initialized with hierarchy: %s', self._client.get_orchestrator_hierarchy()
+        )
         self._repository = repository or InMemoryCampaignRepository()
 
     def submit_campaign(self, campaign: Campaign) -> IntersectCampaignId:
@@ -263,8 +265,12 @@ class CampaignOrchestrator:
 
         This does not apply to Event messages, use another callback for this.
         """
-        logger.info('=== RESPONSE RECEIVED === Orchestrator received response (campaign_id=%s, request_id=%s, source=%s)', 
-                    raw_headers.get('campaign_id'), raw_headers.get('request_id'), raw_headers.get('source'))
+        logger.info(
+            '=== RESPONSE RECEIVED === Orchestrator received response (campaign_id=%s, request_id=%s, source=%s)',
+            raw_headers.get('campaign_id'),
+            raw_headers.get('request_id'),
+            raw_headers.get('source'),
+        )
         # FIXME - several of the fast-return error cases should emit events and CANCEL the campaign
         try:
             headers = validate_userspace_message_headers(raw_headers)
@@ -437,7 +443,10 @@ class CampaignOrchestrator:
                         current_state.campaign_run_id,
                         sorted(str(active_task_id) for active_task_id in execution.active_tasks),
                         sorted(str(pending_task_id) for pending_task_id in execution.pending_tasks),
-                        sorted(str(listener_task_id) for listener_task_id in execution.event_listener_tasks),
+                        sorted(
+                            str(listener_task_id)
+                            for listener_task_id in execution.event_listener_tasks
+                        ),
                     )
                     continue
 
@@ -615,7 +624,9 @@ class CampaignOrchestrator:
             execution.completed_tasks.discard(step_id)
             execution.pending_tasks.add(step_id)
 
-        logger.info('=== STEP COMPLETE === Task %s completed, emitting STEP_COMPLETE event', step_id)
+        logger.info(
+            '=== STEP COMPLETE === Task %s completed, emitting STEP_COMPLETE event', step_id
+        )
         self._emit_event(
             campaign_id=state.campaign.id,
             run_id=state.campaign_run_id,
@@ -715,9 +726,7 @@ class CampaignOrchestrator:
 
     def _finish_campaign(self, state: CampaignState) -> None:
         if state.current_group_index < len(state.task_group_executions):
-            self._close_event_listeners(
-                state.task_group_executions[state.current_group_index]
-            )
+            self._close_event_listeners(state.task_group_executions[state.current_group_index])
         self._emit_event(
             campaign_id=state.campaign.id,
             run_id=state.campaign_run_id,
@@ -790,8 +799,12 @@ class CampaignOrchestrator:
             campaign_id=state.campaign_run_id,
             request_id=task.id,
         )
-        logger.info('Request headers - source: %s, destination: %s, request_id: %s', 
-                    headers.get('source'), headers.get('destination'), headers.get('request_id'))
+        logger.info(
+            'Request headers - source: %s, destination: %s, request_id: %s',
+            headers.get('source'),
+            headers.get('destination'),
+            headers.get('request_id'),
+        )
 
         # The request payload is built from task input defaults in campaign JSON.
         # This allows static per-task configuration like stream IDs and seeds.

--- a/src/intersect_orchestrator/app/core/campaign_orchestrator.py
+++ b/src/intersect_orchestrator/app/core/campaign_orchestrator.py
@@ -265,7 +265,7 @@ class CampaignOrchestrator:
 
         This does not apply to Event messages, use another callback for this.
         """
-        logger.info(
+        logger.debug(
             '=== RESPONSE RECEIVED === Orchestrator received response (campaign_id=%s, request_id=%s, source=%s)',
             raw_headers.get('campaign_id'),
             raw_headers.get('request_id'),
@@ -414,7 +414,7 @@ class CampaignOrchestrator:
             )
             return
 
-        logger.info(
+        logger.debug(
             'Matched event message source=%s capability=%s event_name=%s to %d task(s)',
             headers.source,
             headers.capability_name,

--- a/src/intersect_orchestrator/app/core/campaign_orchestrator.py
+++ b/src/intersect_orchestrator/app/core/campaign_orchestrator.py
@@ -424,6 +424,14 @@ class CampaignOrchestrator:
 
                 execution = current_state.task_group_executions[current_state.current_group_index]
                 if task_id not in execution.active_tasks:
+                    logger.info(
+                        'Skipping matched event task %s for campaign %s because it is not active; active_tasks=%s pending_tasks=%s event_listener_tasks=%s',
+                        task_id,
+                        current_state.campaign_run_id,
+                        sorted(str(active_task_id) for active_task_id in execution.active_tasks),
+                        sorted(str(pending_task_id) for pending_task_id in execution.pending_tasks),
+                        sorted(str(listener_task_id) for listener_task_id in execution.event_listener_tasks),
+                    )
                     continue
 
                 self._record_task_event(
@@ -612,10 +620,11 @@ class CampaignOrchestrator:
         if task.event_name is not None:
             newly_unblocked = self._pop_unblocked_tasks(state, execution)
             logger.info(
-                'Event task %s completed for campaign %s; unblocked %d dependent task(s)',
+                'Event task %s completed for campaign %s; unblocked %d dependent task(s): %s',
                 step_id,
                 state.campaign_run_id,
                 len(newly_unblocked),
+                sorted(str(task_id) for task_id in newly_unblocked),
             )
             if newly_unblocked:
                 for task_id in newly_unblocked:

--- a/src/intersect_orchestrator/app/core/campaign_orchestrator.py
+++ b/src/intersect_orchestrator/app/core/campaign_orchestrator.py
@@ -96,6 +96,8 @@ class TaskGroupExecution:
     """Tasks whose task_dependencies have not yet all completed; not yet dispatched."""
     event_listener_tasks: set[uuid.UUID] = field(default_factory=set)
     """Tasks that have been subscribed for event delivery in the current group."""
+    event_task_match_counts: dict[uuid.UUID, int] = field(default_factory=dict)
+    """Number of matching events consumed by each event task in the current iteration."""
     completed_tasks: set[uuid.UUID] = field(default_factory=set)
     iteration_payloads: dict[uuid.UUID, bytes] = field(default_factory=dict)
 
@@ -501,6 +503,7 @@ class CampaignOrchestrator:
         execution = state.task_group_executions[state.current_group_index]
 
         if execution.objectives_met():
+            self._close_event_listeners(execution)
             # All objectives for this task group are satisfied — advance
             logger.debug(
                 'task group %s objectives met after %d iterations, advancing',
@@ -618,11 +621,15 @@ class CampaignOrchestrator:
         self._store_task_output_values(state, step_id, payload)
 
         if task.event_name is not None:
+            match_count = execution.event_task_match_counts.get(step_id, 0) + 1
+            execution.event_task_match_counts[step_id] = match_count
             newly_unblocked = self._pop_unblocked_tasks(state, execution)
             logger.info(
-                'Event task %s completed for campaign %s; unblocked %d dependent task(s): %s',
+                'Event task %s completed for campaign %s in mode=%s count=%d; unblocked %d dependent task(s): %s',
                 step_id,
                 state.campaign_run_id,
+                task.event_mode,
+                match_count,
                 len(newly_unblocked),
                 sorted(str(task_id) for task_id in newly_unblocked),
             )
@@ -635,16 +642,19 @@ class CampaignOrchestrator:
                     )
                 self._dispatch_task_ids(state, newly_unblocked)
 
-            execution.completed_tasks.discard(step_id)
-            execution.active_tasks.add(step_id)
-            logger.info(
-                'Reactivated event task %s for campaign %s; active_tasks=%d pending_tasks=%d',
-                step_id,
-                state.campaign_run_id,
-                len(execution.active_tasks),
-                len(execution.pending_tasks),
-            )
-            return
+            if self._should_reactivate_event_task(
+                task, match_count, has_unblocked_dependents=bool(newly_unblocked)
+            ):
+                execution.completed_tasks.discard(step_id)
+                execution.active_tasks.add(step_id)
+                logger.info(
+                    'Reactivated event task %s for campaign %s; active_tasks=%d pending_tasks=%d',
+                    step_id,
+                    state.campaign_run_id,
+                    len(execution.active_tasks),
+                    len(execution.pending_tasks),
+                )
+                return
 
         # Unblock any pending tasks whose dependencies are now all satisfied.
         newly_unblocked = self._pop_unblocked_tasks(state, execution)
@@ -666,10 +676,35 @@ class CampaignOrchestrator:
             execution.active_tasks = set()
             execution.pending_tasks = set()
             execution.completed_tasks = set()
+            execution.event_task_match_counts = {}
             execution.iteration_payloads = {}
             self._start_next_iteration(state)
 
+    def _should_reactivate_event_task(
+        self,
+        task: Task,
+        match_count: int,
+        *,
+        has_unblocked_dependents: bool,
+    ) -> bool:
+        if has_unblocked_dependents:
+            return False
+        if task.event_mode == 'persistent':
+            return True
+        if task.event_mode == 'count':
+            return task.event_count is not None and match_count < task.event_count
+        return False
+
+    def _close_event_listeners(self, execution: TaskGroupExecution) -> None:
+        execution.active_tasks.difference_update(execution.event_listener_tasks)
+        execution.pending_tasks.difference_update(execution.event_listener_tasks)
+        execution.event_listener_tasks.clear()
+
     def _finish_campaign(self, state: CampaignState) -> None:
+        if state.current_group_index < len(state.task_group_executions):
+            self._close_event_listeners(
+                state.task_group_executions[state.current_group_index]
+            )
         self._emit_event(
             campaign_id=state.campaign.id,
             run_id=state.campaign_run_id,

--- a/src/intersect_orchestrator/app/core/campaign_orchestrator.py
+++ b/src/intersect_orchestrator/app/core/campaign_orchestrator.py
@@ -142,6 +142,7 @@ class CampaignOrchestrator:
         self._lock = threading.Lock()
         self._campaigns: dict[IntersectCampaignId, CampaignState] = {}
         self._campaign_petri_nets: dict[IntersectCampaignId, PetriNet] = {}
+        logger.info('Orchestrator initialized with hierarchy: %s', self._client.get_orchestrator_hierarchy())
         self._repository = repository or InMemoryCampaignRepository()
 
     def submit_campaign(self, campaign: Campaign) -> IntersectCampaignId:
@@ -262,6 +263,8 @@ class CampaignOrchestrator:
 
         This does not apply to Event messages, use another callback for this.
         """
+        logger.info('=== RESPONSE RECEIVED === Orchestrator received response (campaign_id=%s, request_id=%s, source=%s)', 
+                    raw_headers.get('campaign_id'), raw_headers.get('request_id'), raw_headers.get('source'))
         # FIXME - several of the fast-return error cases should emit events and CANCEL the campaign
         try:
             headers = validate_userspace_message_headers(raw_headers)
@@ -612,6 +615,7 @@ class CampaignOrchestrator:
             execution.completed_tasks.discard(step_id)
             execution.pending_tasks.add(step_id)
 
+        logger.info('=== STEP COMPLETE === Task %s completed, emitting STEP_COMPLETE event', step_id)
         self._emit_event(
             campaign_id=state.campaign.id,
             run_id=state.campaign_run_id,
@@ -786,6 +790,8 @@ class CampaignOrchestrator:
             campaign_id=state.campaign_run_id,
             request_id=task.id,
         )
+        logger.info('Request headers - source: %s, destination: %s, request_id: %s', 
+                    headers.get('source'), headers.get('destination'), headers.get('request_id'))
 
         # The request payload is built from task input defaults in campaign JSON.
         # This allows static per-task configuration like stream IDs and seeds.
@@ -804,7 +810,7 @@ class CampaignOrchestrator:
             headers,
         )
         logger.info(
-            'Dispatching request task %s to hierarchy=%s capability=%s operation=%s',
+            '=== TASK DISPATCH === Sending task %s to service hierarchy: %s (capability=%s, operation=%s)',
             task.id,
             task.hierarchy,
             task.capability,

--- a/src/intersect_orchestrator/app/core/campaign_orchestrator.py
+++ b/src/intersect_orchestrator/app/core/campaign_orchestrator.py
@@ -401,6 +401,14 @@ class CampaignOrchestrator:
             )
             return
 
+        logger.info(
+            'Matched event message source=%s capability=%s event_name=%s to %d task(s)',
+            headers.source,
+            headers.capability_name,
+            headers.event_name,
+            len(matching_steps),
+        )
+
         for state, task_id in matching_steps:
             current_state = self._get_state_for_campaign_alias(state.campaign_run_id)
             if current_state is None:
@@ -575,6 +583,12 @@ class CampaignOrchestrator:
         """Mark a single task as complete. When all tasks in the current iteration
         are done, notify objective checkers and decide whether to iterate again."""
         execution = state.task_group_executions[state.current_group_index]
+        task = self._get_task_from_campaign(state.campaign, step_id)
+        if task is None:
+            msg = f'No task found for step ID: {step_id} in campaign ID: {state.campaign_run_id}'
+            logger.error(msg)
+            self._handle_dispatch_error(state, msg)
+            return
 
         execution.active_tasks.discard(step_id)
         execution.completed_tasks.add(step_id)
@@ -594,6 +608,34 @@ class CampaignOrchestrator:
         # Resolve and store output values from the completed task so downstream
         # tasks (in this or future groups) can reference them via shared value IDs.
         self._store_task_output_values(state, step_id, payload)
+
+        if task.event_name is not None:
+            newly_unblocked = self._pop_unblocked_tasks(state, execution)
+            logger.info(
+                'Event task %s completed for campaign %s; unblocked %d dependent task(s)',
+                step_id,
+                state.campaign_run_id,
+                len(newly_unblocked),
+            )
+            if newly_unblocked:
+                for task_id in newly_unblocked:
+                    self._emit_event(
+                        campaign_id=state.campaign.id,
+                        run_id=state.campaign_run_id,
+                        event=StepStartEvent(step_id=task_id),
+                    )
+                self._dispatch_task_ids(state, newly_unblocked)
+
+            execution.completed_tasks.discard(step_id)
+            execution.active_tasks.add(step_id)
+            logger.info(
+                'Reactivated event task %s for campaign %s; active_tasks=%d pending_tasks=%d',
+                step_id,
+                state.campaign_run_id,
+                len(execution.active_tasks),
+                len(execution.pending_tasks),
+            )
+            return
 
         # Unblock any pending tasks whose dependencies are now all satisfied.
         newly_unblocked = self._pop_unblocked_tasks(state, execution)
@@ -707,6 +749,13 @@ class CampaignOrchestrator:
             'PUBLISHING REQUEST MESSAGE to %s with headers %s',
             task.hierarchy,
             headers,
+        )
+        logger.info(
+            'Dispatching request task %s to hierarchy=%s capability=%s operation=%s',
+            task.id,
+            task.hierarchy,
+            task.capability,
+            task.operation_id,
         )
         self._client.publish_request_message(
             task.hierarchy,
@@ -847,6 +896,13 @@ class CampaignOrchestrator:
             return
 
         try:
+            logger.info(
+                'Subscribing event task %s to hierarchy=%s capability=%s event_name=%s',
+                task.id,
+                task.hierarchy,
+                task.capability,
+                task.event_name,
+            )
             self._client.subscribe_to_events(
                 task.hierarchy,
                 task.capability,

--- a/src/intersect_orchestrator/app/core/campaign_orchestrator.py
+++ b/src/intersect_orchestrator/app/core/campaign_orchestrator.py
@@ -98,6 +98,8 @@ class TaskGroupExecution:
     """Tasks that have been subscribed for event delivery in the current group."""
     event_task_match_counts: dict[uuid.UUID, int] = field(default_factory=dict)
     """Number of matching events consumed by each event task in the current iteration."""
+    requeue_after_completion: set[uuid.UUID] = field(default_factory=set)
+    """Tasks that should return to pending after their current dispatch completes."""
     completed_tasks: set[uuid.UUID] = field(default_factory=set)
     iteration_payloads: dict[uuid.UUID, bytes] = field(default_factory=dict)
 
@@ -605,6 +607,11 @@ class CampaignOrchestrator:
         execution.completed_tasks.add(step_id)
         execution.iteration_payloads[step_id] = payload
 
+        if step_id in execution.requeue_after_completion:
+            execution.requeue_after_completion.discard(step_id)
+            execution.completed_tasks.discard(step_id)
+            execution.pending_tasks.add(step_id)
+
         self._emit_event(
             campaign_id=state.campaign.id,
             run_id=state.campaign_run_id,
@@ -645,6 +652,7 @@ class CampaignOrchestrator:
             if self._should_reactivate_event_task(
                 task, match_count, has_unblocked_dependents=bool(newly_unblocked)
             ):
+                execution.requeue_after_completion.update(newly_unblocked)
                 execution.completed_tasks.discard(step_id)
                 execution.active_tasks.add(step_id)
                 logger.info(
@@ -677,6 +685,7 @@ class CampaignOrchestrator:
             execution.pending_tasks = set()
             execution.completed_tasks = set()
             execution.event_task_match_counts = {}
+            execution.requeue_after_completion = set()
             execution.iteration_payloads = {}
             self._start_next_iteration(state)
 
@@ -687,12 +696,12 @@ class CampaignOrchestrator:
         *,
         has_unblocked_dependents: bool,
     ) -> bool:
-        if has_unblocked_dependents:
-            return False
         if task.event_mode == 'persistent':
             return True
         if task.event_mode == 'count':
             return task.event_count is not None and match_count < task.event_count
+        if has_unblocked_dependents:
+            return False
         return False
 
     def _close_event_listeners(self, execution: TaskGroupExecution) -> None:

--- a/src/intersect_orchestrator/app/core/campaign_orchestrator.py
+++ b/src/intersect_orchestrator/app/core/campaign_orchestrator.py
@@ -665,7 +665,10 @@ class CampaignOrchestrator:
                 self._dispatch_task_ids(state, newly_unblocked)
 
             if self._should_reactivate_event_task(
-                task, match_count, has_unblocked_dependents=bool(newly_unblocked)
+                task,
+                match_count,
+                has_unblocked_dependents=bool(newly_unblocked),
+                execution=execution,
             ):
                 execution.requeue_after_completion.update(newly_unblocked)
                 execution.completed_tasks.discard(step_id)
@@ -710,7 +713,18 @@ class CampaignOrchestrator:
         match_count: int,
         *,
         has_unblocked_dependents: bool,
+        execution: TaskGroupExecution,
     ) -> bool:
+        # For single-pass campaigns (no objectives, first iteration) with non-event tasks,
+        # don't reactivate persistent listeners — let the campaign complete after request tasks finish.
+        # Event-only campaigns (all tasks are event listeners) should keep reactivating.
+        if not execution.objective_checkers and execution.current_iteration == 0:
+            all_tasks_are_event_listeners = (
+                set(execution.task_ids) == execution.event_listener_tasks
+            )
+            if not all_tasks_are_event_listeners and task.event_mode == 'persistent':
+                return False
+
         if task.event_mode == 'persistent':
             return True
         if task.event_mode == 'count':

--- a/src/intersect_orchestrator/app/core/environment.py
+++ b/src/intersect_orchestrator/app/core/environment.py
@@ -1,4 +1,5 @@
-import uuid
+from datetime import UTC, datetime
+from functools import cached_property
 from typing import Annotated, Literal
 
 from pydantic import BeforeValidator, Field, HttpUrl, PositiveInt
@@ -13,9 +14,9 @@ from .definitions import (
 )
 
 
-def _generate_short_uuid() -> str:
-    """Generate a short 7-character UUID suffix for queue names."""
-    return uuid.uuid4().hex[:7]
+def _generate_timestamp_suffix() -> str:
+    """Generate a timestamp suffix for queue names (ISO format with microseconds)."""
+    return datetime.now(UTC).strftime('%Y%m%dT%H%M%S%f')
 
 
 LogLevel = Literal['CRITICAL', 'FATAL', 'ERROR', 'WARNING', 'WARN', 'INFO', 'DEBUG']
@@ -77,15 +78,31 @@ class Settings(BaseSettings):
     The System name is used as part of how INTERSECT clients know who to connect to, and can be shared with anyone.
     """
 
-    QUEUE_NAME_SUFFIX: str = Field(default_factory=_generate_short_uuid)
+    AUTOGEN_QUEUE_SUFFIX: bool = False
     """
-    Suffix appended to AMQP queue names to ensure uniqueness across multiple orchestrator instances.
+    If True, append an auto-generated timestamp to the queue name suffix.
+    This ensures unique queue names across orchestrator instances.
     
-    By default, a random 7-character UUID is generated. Set this explicitly to share queues
-    between restarts (e.g., for sticky session behavior) or to completely isolate instances.
+    Use this when running multiple isolated orchestrators against the same broker.
+    """
+
+    QUEUE_NAME_SUFFIX: str = ''
+    """
+    Optional suffix appended to AMQP queue names.
+    
+    Set this to isolate orchestrator instances or identify them in the broker.
+    Combined with AUTOGEN_QUEUE_SUFFIX=True for fully unique names.
     
     Example: QUEUE_NAME_SUFFIX=dev01 would create queues like 'intersect-orchestrator-dev01'
     """
+
+    @cached_property
+    def queue_name_suffix(self) -> str:
+        """Compute the full queue name suffix, including auto-generated part if enabled."""
+        suffix = f'-{self.QUEUE_NAME_SUFFIX}' if self.QUEUE_NAME_SUFFIX else ''
+        if not self.AUTOGEN_QUEUE_SUFFIX:
+            return suffix
+        return f'{suffix}-{_generate_timestamp_suffix()}'
 
     # TODO - should allow for multiple brokers levels eventually.
     BROKER_HOST: str = 'localhost'

--- a/src/intersect_orchestrator/app/core/environment.py
+++ b/src/intersect_orchestrator/app/core/environment.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Annotated, Literal
 
 from pydantic import BeforeValidator, Field, HttpUrl, PositiveInt
@@ -10,6 +11,11 @@ from .definitions import (
     HIERARCHY_REGEX,
     BrokerProtocol,
 )
+
+
+def _generate_short_uuid() -> str:
+    """Generate a short 7-character UUID suffix for queue names."""
+    return uuid.uuid4().hex[:7]
 
 LogLevel = Literal['CRITICAL', 'FATAL', 'ERROR', 'WARNING', 'WARN', 'INFO', 'DEBUG']
 
@@ -68,6 +74,16 @@ class Settings(BaseSettings):
     )
     """
     The System name is used as part of how INTERSECT clients know who to connect to, and can be shared with anyone.
+    """
+
+    QUEUE_NAME_SUFFIX: str = Field(default_factory=_generate_short_uuid)
+    """
+    Suffix appended to AMQP queue names to ensure uniqueness across multiple orchestrator instances.
+    
+    By default, a random 7-character UUID is generated. Set this explicitly to share queues
+    between restarts (e.g., for sticky session behavior) or to completely isolate instances.
+    
+    Example: QUEUE_NAME_SUFFIX=dev01 would create queues like 'intersect-orchestrator-dev01'
     """
 
     # TODO - should allow for multiple brokers levels eventually.

--- a/src/intersect_orchestrator/app/core/environment.py
+++ b/src/intersect_orchestrator/app/core/environment.py
@@ -17,6 +17,7 @@ def _generate_short_uuid() -> str:
     """Generate a short 7-character UUID suffix for queue names."""
     return uuid.uuid4().hex[:7]
 
+
 LogLevel = Literal['CRITICAL', 'FATAL', 'ERROR', 'WARNING', 'WARN', 'INFO', 'DEBUG']
 
 

--- a/src/intersect_orchestrator/app/core/intersect_client.py
+++ b/src/intersect_orchestrator/app/core/intersect_client.py
@@ -31,6 +31,7 @@ _log = logging.getLogger(__name__)
 
 RESERVED_QUEUE_NAME = 'intersect-orchestrator'
 EVENT_QUEUE_NAME = 'intersect-orchestrator-events'
+EVENT_WILDCARD_CHANNEL = '*#'
 
 
 class CoreServiceIntersectClient:
@@ -44,7 +45,7 @@ class CoreServiceIntersectClient:
     def __init__(self, settings: Settings) -> None:
         self.http_connections: set[Queue[bytes]] = set()
         self.campaign_orchestrator: CampaignOrchestrator | None = None
-        self._event_subscription_channels: set[str] = set()
+        self._event_subscription_registered = False
         """
         self.message_validator: TypeAdapter[EventMessage | LifecycleMessage | UserspaceMessage] = (
             TypeAdapter(EventMessage | LifecycleMessage | UserspaceMessage)
@@ -74,14 +75,20 @@ class CoreServiceIntersectClient:
         TODO - the registry service needs to make sure to disallow non-root users from subscribing to this channel (publishing is universal)
         """
 
-        self.control_plane_manager.connect()
-        # must add "/response" suffix due to INTERSECT-SDK convention
         self.control_plane_manager.add_subscription_channel(
             f'{self.orchestrator_base_topic}/response',
             {self._handle_message},
             True,
             RESERVED_QUEUE_NAME,
         )
+        self.control_plane_manager.add_subscription_channel(
+            EVENT_WILDCARD_CHANNEL,
+            {self._handle_event_message},
+            True,
+            EVENT_QUEUE_NAME,
+        )
+        self._event_subscription_registered = True
+        self.control_plane_manager.connect()
 
     def _handle_message(self, message: bytes, content_type: str, headers: dict[str, str]) -> None:
         """Broker callback calls this function when we get a message."""
@@ -100,16 +107,9 @@ class CoreServiceIntersectClient:
         # (this will eventually be managed by checking the message's Content-Type)
 
         if self.campaign_orchestrator is not None:
-            # Some broker/control-plane configurations can route event traffic
-            # through this callback. Detect event headers and forward them.
-            if 'event_name' in headers and 'capability_name' in headers:
-                self.campaign_orchestrator.handle_event_broker_message(
-                    message, content_type, headers
-                )
-            else:
-                self.campaign_orchestrator.handle_request_reply_broker_message(
-                    message, content_type, headers
-                )
+            self.campaign_orchestrator.handle_request_reply_broker_message(
+                message, content_type, headers
+            )
 
         for connection in self.http_connections:
             connection.put_nowait(message)
@@ -127,20 +127,17 @@ class CoreServiceIntersectClient:
         capability_name: str,
         event_name: str,
     ) -> None:
-        """Subscribe orchestrator to a specific service event channel."""
-        channel = (
-            f'{self._hierarchy_to_channel(service_hierarchy)}/events/{capability_name}/{event_name}'
-        )
-        if channel in self._event_subscription_channels:
+        """Ensure the shared wildcard event subscription is registered once."""
+        if self._event_subscription_registered:
             return
 
         self.control_plane_manager.add_subscription_channel(
-            channel,
+            EVENT_WILDCARD_CHANNEL,
             {self._handle_event_message},
             True,
             EVENT_QUEUE_NAME,
         )
-        self._event_subscription_channels.add(channel)
+        self._event_subscription_registered = True
 
     def get_orchestrator_hierarchy(self) -> str:
         """Return orchestrator source hierarchy in dot-separated header format."""

--- a/src/intersect_orchestrator/app/core/intersect_client.py
+++ b/src/intersect_orchestrator/app/core/intersect_client.py
@@ -34,7 +34,12 @@ _QUEUE_NAME_PREFIX = 'intersect-orchestrator'
 _EVENT_QUEUE_NAME_PREFIX = 'intersect-orchestrator-events'
 # TODO: orchestrator should only listen for events the active campaigns are interested in,
 # and when it's done listening for an event it should unsubscribe
-EVENT_WILDCARD_CHANNEL = '#'
+#
+# NOTE: As of intersect-sdk-common 0.9.5, must use *# and not # due to SDK
+# error: "intersect_sdk_common.exceptions.IntersectSetupError: Channel # is not valid,"
+#        "it must be alphanumeric and can only contain the following "
+#        "special characters: * # / -"
+EVENT_WILDCARD_CHANNEL = '*#'
 
 
 class CoreServiceIntersectClient:

--- a/src/intersect_orchestrator/app/core/intersect_client.py
+++ b/src/intersect_orchestrator/app/core/intersect_client.py
@@ -74,6 +74,9 @@ class CoreServiceIntersectClient:
 
         TODO - the registry service needs to make sure to disallow non-root users from subscribing to this channel (publishing is universal)
         """
+        _log.info(f'Orchestrator base topic: {self.orchestrator_base_topic}')
+        _log.info(f'Orchestrator hierarchy: {self._channel_to_hierarchy(self.orchestrator_base_topic)}')
+        _log.info(f'Subscribing to response channel: {self.orchestrator_base_topic}/response')
 
         self.control_plane_manager.add_subscription_channel(
             f'{self.orchestrator_base_topic}/response',

--- a/src/intersect_orchestrator/app/core/intersect_client.py
+++ b/src/intersect_orchestrator/app/core/intersect_client.py
@@ -36,6 +36,7 @@ _EVENT_QUEUE_NAME_PREFIX = 'intersect-orchestrator-events'
 # and when it's done listening for an event it should unsubscribe
 EVENT_WILDCARD_CHANNEL = '#'
 
+
 class CoreServiceIntersectClient:
     """
     This class handles interactions with INTERSECT and also helps out with broadcasting websocket events to connected clients.
@@ -49,11 +50,10 @@ class CoreServiceIntersectClient:
         self.campaign_orchestrator: CampaignOrchestrator | None = None
         self._event_subscription_registered = False
 
-        # Generate unique queue names using the suffix from settings
-        # This prevents multiple orchestrator instances from stealing each other's messages
-        queue_suffix = settings.QUEUE_NAME_SUFFIX
-        self._queue_name = f'{_QUEUE_NAME_PREFIX}-{queue_suffix}'
-        self._event_queue_name = f'{_EVENT_QUEUE_NAME_PREFIX}-{queue_suffix}'
+        # Generate queue names using the suffix from settings
+        queue_suffix = settings.queue_name_suffix
+        self._queue_name = f'{_QUEUE_NAME_PREFIX}{queue_suffix}'
+        self._event_queue_name = f'{_EVENT_QUEUE_NAME_PREFIX}{queue_suffix}'
         _log.info(f'Using unique queue names: {self._queue_name}, {self._event_queue_name}')
 
         """

--- a/src/intersect_orchestrator/app/core/intersect_client.py
+++ b/src/intersect_orchestrator/app/core/intersect_client.py
@@ -137,11 +137,17 @@ class CoreServiceIntersectClient:
 
     def subscribe_to_events(
         self,
-        service_hierarchy: str,
-        capability_name: str,
-        event_name: str,
+        _service_hierarchy: str,
+        _capability_name: str,
+        _event_name: str,
     ) -> None:
-        """Ensure the shared wildcard event subscription is registered once."""
+        """Ensure the shared wildcard event subscription is registered once.
+
+        The parameters are part of the public interface (callers specify the
+        exact service/capability/event), but the current implementation uses a
+        single wildcard subscription for all events. Parameters are preserved
+        for future filtering or logging enhancements.
+        """
         if self._event_subscription_registered:
             return
 

--- a/src/intersect_orchestrator/app/core/intersect_client.py
+++ b/src/intersect_orchestrator/app/core/intersect_client.py
@@ -47,7 +47,7 @@ class CoreServiceIntersectClient:
         self.http_connections: set[Queue[bytes]] = set()
         self.campaign_orchestrator: CampaignOrchestrator | None = None
         self._event_subscription_registered = False
-        
+
         # Generate unique queue names using the suffix from settings
         # This prevents multiple orchestrator instances from stealing each other's messages
         queue_suffix = settings.QUEUE_NAME_SUFFIX
@@ -149,7 +149,7 @@ class CoreServiceIntersectClient:
             EVENT_WILDCARD_CHANNEL,
             {self._handle_event_message},
             True,
-            EVENT_QUEUE_NAME,
+            self._event_queue_name,
         )
         self._event_subscription_registered = True
 

--- a/src/intersect_orchestrator/app/core/intersect_client.py
+++ b/src/intersect_orchestrator/app/core/intersect_client.py
@@ -32,6 +32,8 @@ _log = logging.getLogger(__name__)
 # Base queue name prefixes - suffix is added from settings for uniqueness
 _QUEUE_NAME_PREFIX = 'intersect-orchestrator'
 _EVENT_QUEUE_NAME_PREFIX = 'intersect-orchestrator-events'
+# TODO: orchestrator should only listen for events the active campaigns are interested in,
+# and when it's done listening for an event it should unsubscribe
 EVENT_WILDCARD_CHANNEL = '#'
 
 class CoreServiceIntersectClient:

--- a/src/intersect_orchestrator/app/core/intersect_client.py
+++ b/src/intersect_orchestrator/app/core/intersect_client.py
@@ -29,8 +29,9 @@ from intersect_sdk._internal.messages.userspace import UserspaceMessage
 _log = logging.getLogger(__name__)
 
 
-RESERVED_QUEUE_NAME = 'intersect-orchestrator'
-EVENT_QUEUE_NAME = 'intersect-orchestrator-events'
+# Base queue name prefixes - suffix is added from settings for uniqueness
+_QUEUE_NAME_PREFIX = 'intersect-orchestrator'
+_EVENT_QUEUE_NAME_PREFIX = 'intersect-orchestrator-events'
 EVENT_WILDCARD_CHANNEL = '*#'
 
 
@@ -46,6 +47,14 @@ class CoreServiceIntersectClient:
         self.http_connections: set[Queue[bytes]] = set()
         self.campaign_orchestrator: CampaignOrchestrator | None = None
         self._event_subscription_registered = False
+        
+        # Generate unique queue names using the suffix from settings
+        # This prevents multiple orchestrator instances from stealing each other's messages
+        queue_suffix = settings.QUEUE_NAME_SUFFIX
+        self._queue_name = f'{_QUEUE_NAME_PREFIX}-{queue_suffix}'
+        self._event_queue_name = f'{_EVENT_QUEUE_NAME_PREFIX}-{queue_suffix}'
+        _log.info(f'Using unique queue names: {self._queue_name}, {self._event_queue_name}')
+
         """
         self.message_validator: TypeAdapter[EventMessage | LifecycleMessage | UserspaceMessage] = (
             TypeAdapter(EventMessage | LifecycleMessage | UserspaceMessage)
@@ -84,13 +93,13 @@ class CoreServiceIntersectClient:
             f'{self.orchestrator_base_topic}/response',
             {self._handle_message},
             True,
-            RESERVED_QUEUE_NAME,
+            self._queue_name,
         )
         self.control_plane_manager.add_subscription_channel(
             EVENT_WILDCARD_CHANNEL,
             {self._handle_event_message},
             True,
-            EVENT_QUEUE_NAME,
+            self._event_queue_name,
         )
         self._event_subscription_registered = True
         self.control_plane_manager.connect()

--- a/src/intersect_orchestrator/app/core/intersect_client.py
+++ b/src/intersect_orchestrator/app/core/intersect_client.py
@@ -32,8 +32,7 @@ _log = logging.getLogger(__name__)
 # Base queue name prefixes - suffix is added from settings for uniqueness
 _QUEUE_NAME_PREFIX = 'intersect-orchestrator'
 _EVENT_QUEUE_NAME_PREFIX = 'intersect-orchestrator-events'
-EVENT_WILDCARD_CHANNEL = '*#'
-
+EVENT_WILDCARD_CHANNEL = '#'
 
 class CoreServiceIntersectClient:
     """

--- a/src/intersect_orchestrator/app/core/intersect_client.py
+++ b/src/intersect_orchestrator/app/core/intersect_client.py
@@ -75,7 +75,9 @@ class CoreServiceIntersectClient:
         TODO - the registry service needs to make sure to disallow non-root users from subscribing to this channel (publishing is universal)
         """
         _log.info(f'Orchestrator base topic: {self.orchestrator_base_topic}')
-        _log.info(f'Orchestrator hierarchy: {self._channel_to_hierarchy(self.orchestrator_base_topic)}')
+        _log.info(
+            f'Orchestrator hierarchy: {self._channel_to_hierarchy(self.orchestrator_base_topic)}'
+        )
         _log.info(f'Subscribing to response channel: {self.orchestrator_base_topic}/response')
 
         self.control_plane_manager.add_subscription_channel(

--- a/tests/unit/app/api/v1/endpoints/orchestrator/models/test_campaign.py
+++ b/tests/unit/app/api/v1/endpoints/orchestrator/models/test_campaign.py
@@ -1,5 +1,7 @@
 from uuid import UUID
 
+import pytest
+
 from intersect_orchestrator.app.api.v1.endpoints.orchestrator.models.campaign import Campaign
 
 
@@ -47,3 +49,93 @@ def test_random_number_and_histogram_campaign_data(random_number_and_histogram_c
 
     assert len(viz_group.tasks) == 2
     assert viz_group.tasks[1].task_dependencies == [UUID('93b5f409-ae29-413d-96a9-b173d0265f25')]
+
+
+def test_event_task_defaults_to_once_mode():
+    campaign = Campaign(
+        id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1',
+        run_id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2',
+        name='event-mode-default',
+        user='test-user',
+        description='Validate default event mode',
+        task_groups=[
+            {
+                'id': 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3',
+                'group_dependencies': [],
+                'tasks': [
+                    {
+                        'id': 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4',
+                        'hierarchy': 'org.fac.system.subsystem.service',
+                        'capability': 'capability',
+                        'event_name': 'condition_met',
+                        'task_dependencies': [],
+                        'task_objectives': None,
+                    }
+                ],
+                'objectives': [],
+            }
+        ],
+    )
+
+    assert campaign.task_groups[0].tasks[0].event_mode == 'once'
+    assert campaign.task_groups[0].tasks[0].event_count is None
+
+
+def test_count_mode_requires_positive_event_count():
+    with pytest.raises(ValueError, match='event_count'):
+        Campaign(
+            id='bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1',
+            run_id='bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2',
+            name='event-mode-count',
+            user='test-user',
+            description='Validate count mode',
+            task_groups=[
+                {
+                    'id': 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3',
+                    'group_dependencies': [],
+                    'tasks': [
+                        {
+                            'id': 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4',
+                            'hierarchy': 'org.fac.system.subsystem.service',
+                            'capability': 'capability',
+                            'event_name': 'histogram_updated',
+                            'event_mode': 'count',
+                            'event_count': 0,
+                            'task_dependencies': [],
+                            'task_objectives': None,
+                        }
+                    ],
+                    'objectives': [],
+                }
+            ],
+        )
+
+
+def test_persistent_mode_rejects_event_count():
+    with pytest.raises(ValueError, match='event_count'):
+        Campaign(
+            id='cccccccc-cccc-4ccc-8ccc-ccccccccccc1',
+            run_id='cccccccc-cccc-4ccc-8ccc-ccccccccccc2',
+            name='event-mode-persistent',
+            user='test-user',
+            description='Validate persistent mode',
+            task_groups=[
+                {
+                    'id': 'cccccccc-cccc-4ccc-8ccc-ccccccccccc3',
+                    'group_dependencies': [],
+                    'tasks': [
+                        {
+                            'id': 'cccccccc-cccc-4ccc-8ccc-ccccccccccc4',
+                            'hierarchy': 'org.fac.system.subsystem.service',
+                            'capability': 'capability',
+                            'event_name': 'histogram_updated',
+                            'event_mode': 'persistent',
+                            'event_count': 2,
+                            'task_dependencies': [],
+                            'task_objectives': None,
+                        }
+                    ],
+                    'objectives': [],
+                }
+            ],
+        )

--- a/tests/unit/app/core/repository/test_petri_net_transitions.py
+++ b/tests/unit/app/core/repository/test_petri_net_transitions.py
@@ -28,6 +28,9 @@ class _FakeClient:
     def broadcast_message(self, message: bytes) -> None:
         self.broadcasts.append(message)
 
+    def get_orchestrator_hierarchy(self) -> str:
+        return 'test.orchestrator'
+
 
 @pytest.fixture
 def repository() -> InMemoryCampaignRepository:

--- a/tests/unit/test_campaign_orchestrator.py
+++ b/tests/unit/test_campaign_orchestrator.py
@@ -121,6 +121,43 @@ def _make_event_campaign(campaign_id: uuid.UUID, step_id: uuid.UUID) -> Campaign
     )
 
 
+def _make_event_mode_campaign(
+    campaign_id: uuid.UUID,
+    step_id: uuid.UUID,
+    *,
+    event_mode: str,
+    event_count: int | None = None,
+) -> Campaign:
+    return Campaign(
+        id=campaign_id,
+        run_id=campaign_id,
+        name='test-event-mode-campaign',
+        user='test-user',
+        description='Test campaign for event mode handling',
+        task_groups=[
+            {
+                'id': str(uuid.uuid4()),
+                'tasks': [
+                    {
+                        'id': str(step_id),
+                        'hierarchy': 'org.fac.system.subsystem.service',
+                        'capability': 'RandomNumberGenerator',
+                        'event_name': 'newMeasurement',
+                        'event_mode': event_mode,
+                        'event_count': event_count,
+                        'output': None,
+                        'input': None,
+                        'task_dependencies': [],
+                        'task_objectives': None,
+                    }
+                ],
+                'group_dependencies': [],
+                'objectives': [],
+            }
+        ],
+    )
+
+
 def test_handle_broker_message_completes_step() -> None:
     client = FakeClient()
     orchestrator = CampaignOrchestrator(client)
@@ -258,6 +295,303 @@ def test_handle_event_broker_message_completes_event_task() -> None:
         'STEP_COMPLETE',
         'CAMPAIGN_COMPLETE',
     ]
+
+
+def test_once_event_task_completes_permanently_after_first_match() -> None:
+    client = FakeClient()
+    orchestrator = CampaignOrchestrator(client)
+
+    campaign_id = uuid.uuid4()
+    step_id = uuid.uuid4()
+    campaign = _make_event_mode_campaign(campaign_id, step_id, event_mode='once')
+
+    orchestrator.submit_campaign(campaign)
+
+    headers = {
+        'message_id': str(uuid.uuid4()),
+        'source': 'org.fac.system.subsystem.service',
+        'created_at': '2024-01-01T00:00:00Z',
+        'sdk_version': '0.0.1',
+        'data_handler': 'MESSAGE',
+        'capability_name': 'RandomNumberGenerator',
+        'event_name': 'newMeasurement',
+    }
+
+    orchestrator.handle_event_broker_message(b'{"value": 1}', 'application/json', headers)
+    orchestrator.handle_event_broker_message(b'{"value": 2}', 'application/json', headers)
+
+    assert _event_types(client.broadcasts) == [
+        'STEP_START',
+        'STEP_COMPLETE',
+        'CAMPAIGN_COMPLETE',
+    ]
+
+
+def test_count_event_task_completes_after_configured_matches() -> None:
+    client = FakeClient()
+    orchestrator = CampaignOrchestrator(client)
+
+    campaign_id = uuid.uuid4()
+    step_id = uuid.uuid4()
+    campaign = _make_event_mode_campaign(
+        campaign_id,
+        step_id,
+        event_mode='count',
+        event_count=2,
+    )
+
+    orchestrator.submit_campaign(campaign)
+
+    headers = {
+        'message_id': str(uuid.uuid4()),
+        'source': 'org.fac.system.subsystem.service',
+        'created_at': '2024-01-01T00:00:00Z',
+        'sdk_version': '0.0.1',
+        'data_handler': 'MESSAGE',
+        'capability_name': 'RandomNumberGenerator',
+        'event_name': 'newMeasurement',
+    }
+
+    orchestrator.handle_event_broker_message(b'{"value": 1}', 'application/json', headers)
+    assert _event_types(client.broadcasts) == ['STEP_START', 'STEP_COMPLETE']
+
+    orchestrator.handle_event_broker_message(b'{"value": 2}', 'application/json', headers)
+    assert _event_types(client.broadcasts) == [
+        'STEP_START',
+        'STEP_COMPLETE',
+        'STEP_COMPLETE',
+        'CAMPAIGN_COMPLETE',
+    ]
+
+
+def test_persistent_event_task_reactivates_after_match() -> None:
+    client = FakeClient()
+    orchestrator = CampaignOrchestrator(client)
+
+    campaign_id = uuid.uuid4()
+    step_id = uuid.uuid4()
+    campaign = _make_event_mode_campaign(campaign_id, step_id, event_mode='persistent')
+
+    orchestrator.submit_campaign(campaign)
+
+    headers = {
+        'message_id': str(uuid.uuid4()),
+        'source': 'org.fac.system.subsystem.service',
+        'created_at': '2024-01-01T00:00:00Z',
+        'sdk_version': '0.0.1',
+        'data_handler': 'MESSAGE',
+        'capability_name': 'RandomNumberGenerator',
+        'event_name': 'newMeasurement',
+    }
+
+    orchestrator.handle_event_broker_message(b'{"value": 1}', 'application/json', headers)
+    orchestrator.handle_event_broker_message(b'{"value": 2}', 'application/json', headers)
+
+    assert _event_types(client.broadcasts) == [
+        'STEP_START',
+        'STEP_COMPLETE',
+        'STEP_COMPLETE',
+    ]
+
+
+def test_once_event_chain_advances_one_gate_per_event() -> None:
+    client = FakeClient()
+    orchestrator = CampaignOrchestrator(client)
+
+    campaign_id = uuid.uuid4()
+    first_event_id = uuid.uuid4()
+    first_request_id = uuid.uuid4()
+    second_event_id = uuid.uuid4()
+    second_request_id = uuid.uuid4()
+
+    campaign = Campaign(
+        id=campaign_id,
+        run_id=campaign_id,
+        name='serialized-event-chain',
+        user='test-user',
+        description='Ensure once-mode event gates serialize a chain',
+        task_groups=[
+            {
+                'id': str(uuid.uuid4()),
+                'group_dependencies': [],
+                'tasks': [
+                    {
+                        'id': str(first_event_id),
+                        'hierarchy': 'org.fac.system.subsystem.service',
+                        'capability': 'SurrogateDiffraction',
+                        'event_name': 'condition_met',
+                        'event_mode': 'once',
+                        'output': None,
+                        'input': None,
+                        'task_dependencies': [],
+                        'task_objectives': None,
+                    },
+                    {
+                        'id': str(first_request_id),
+                        'hierarchy': 'org.fac.system.subsystem.instrument',
+                        'capability': 'InstrumentControl',
+                        'operation_id': 'move_sample',
+                        'output': None,
+                        'input': None,
+                        'task_dependencies': [str(first_event_id)],
+                        'task_objectives': None,
+                    },
+                    {
+                        'id': str(second_event_id),
+                        'hierarchy': 'org.fac.system.subsystem.service',
+                        'capability': 'SurrogateDiffraction',
+                        'event_name': 'condition_met',
+                        'event_mode': 'once',
+                        'output': None,
+                        'input': None,
+                        'task_dependencies': [str(first_request_id)],
+                        'task_objectives': None,
+                    },
+                    {
+                        'id': str(second_request_id),
+                        'hierarchy': 'org.fac.system.subsystem.instrument',
+                        'capability': 'InstrumentControl',
+                        'operation_id': 'move_sample',
+                        'output': None,
+                        'input': None,
+                        'task_dependencies': [str(second_event_id)],
+                        'task_objectives': None,
+                    },
+                ],
+                'objectives': [],
+            }
+        ],
+    )
+
+    orchestrator.submit_campaign(campaign)
+
+    event_headers = {
+        'message_id': str(uuid.uuid4()),
+        'source': 'org.fac.system.subsystem.service',
+        'created_at': '2024-01-01T00:00:00Z',
+        'sdk_version': '0.0.1',
+        'data_handler': 'MESSAGE',
+        'capability_name': 'SurrogateDiffraction',
+        'event_name': 'condition_met',
+    }
+
+    orchestrator.handle_event_broker_message(b'{"value": 1}', 'application/json', event_headers)
+
+    event_types = _event_types(client.broadcasts)
+    assert event_types == ['STEP_START', 'STEP_COMPLETE', 'STEP_START']
+
+    state = orchestrator._campaigns[campaign_id]
+    execution = state.task_group_executions[state.current_group_index]
+    assert first_event_id not in execution.active_tasks
+    assert second_event_id in execution.pending_tasks
+
+    orchestrator.handle_request_reply_broker_message(
+        b'{}',
+        'application/json',
+        {
+            'has_error': 'false',
+            'source': 'org.fac.system.subsystem.instrument',
+            'campaign_id': str(campaign_id),
+            'request_id': str(first_request_id),
+            'message_id': str(uuid.uuid4()),
+            'destination': 'test.orchestrator',
+            'sdk_version': '0.0.1',
+            'created_at': '2024-01-01T00:00:00Z',
+            'operation_id': 'InstrumentControl.move_sample',
+        },
+    )
+
+    execution = orchestrator._campaigns[campaign_id].task_group_executions[0]
+    assert second_event_id in execution.active_tasks
+
+    orchestrator.handle_event_broker_message(b'{"value": 2}', 'application/json', event_headers)
+
+    event_types = _event_types(client.broadcasts)
+    assert event_types.count('STEP_COMPLETE') == 3
+    assert event_types.count('STEP_START') == 4
+
+
+def test_persistent_listener_closes_when_campaign_completes() -> None:
+    client = FakeClient()
+    orchestrator = CampaignOrchestrator(client)
+
+    campaign_id = uuid.uuid4()
+    event_task_id = uuid.uuid4()
+    request_task_id = uuid.uuid4()
+    task_group_id = uuid.uuid4()
+
+    campaign = Campaign(
+        id=campaign_id,
+        run_id=campaign_id,
+        name='persistent-objective-close',
+        user='test-user',
+        description='Persistent listener should close when campaign completes',
+        task_groups=[
+            {
+                'id': str(task_group_id),
+                'group_dependencies': [],
+                'tasks': [
+                    {
+                        'id': str(event_task_id),
+                        'hierarchy': 'org.fac.system.subsystem.analysis',
+                        'capability': 'LiveStreamAnalysis',
+                        'event_name': 'histogram_updated',
+                        'event_mode': 'persistent',
+                        'output': None,
+                        'input': None,
+                        'task_dependencies': [],
+                        'task_objectives': None,
+                    },
+                    {
+                        'id': str(request_task_id),
+                        'hierarchy': 'org.fac.system.subsystem.surrogate',
+                        'capability': 'SurrogateDiffraction',
+                        'operation_id': 'update_with_data',
+                        'output': None,
+                        'input': None,
+                        'task_dependencies': [str(event_task_id)],
+                        'task_objectives': None,
+                    },
+                ],
+                'objectives': [],
+            }
+        ],
+    )
+
+    orchestrator.submit_campaign(campaign)
+
+    event_headers = {
+        'message_id': str(uuid.uuid4()),
+        'source': 'org.fac.system.subsystem.analysis',
+        'created_at': '2024-01-01T00:00:00Z',
+        'sdk_version': '0.0.1',
+        'data_handler': 'MESSAGE',
+        'capability_name': 'LiveStreamAnalysis',
+        'event_name': 'histogram_updated',
+    }
+
+    orchestrator.handle_event_broker_message(b'{"value": 1}', 'application/json', event_headers)
+    orchestrator.handle_request_reply_broker_message(
+        b'{}',
+        'application/json',
+        {
+            'has_error': 'false',
+            'source': 'org.fac.system.subsystem.surrogate',
+            'campaign_id': str(campaign_id),
+            'request_id': str(request_task_id),
+            'message_id': str(uuid.uuid4()),
+            'destination': 'test.orchestrator',
+            'sdk_version': '0.0.1',
+            'created_at': '2024-01-01T00:00:00Z',
+            'operation_id': 'SurrogateDiffraction.update_with_data',
+        },
+    )
+
+    assert campaign_id not in orchestrator._campaigns
+
+    before = len(client.broadcasts)
+    orchestrator.handle_event_broker_message(b'{"value": 2}', 'application/json', event_headers)
+    assert len(client.broadcasts) == before
 
 
 def test_event_task_payload_populates_downstream_request_inputs_without_explicit_output() -> None:


### PR DESCRIPTION
Work includes:
  New event mode for tasks:
    - Adds `event_mode` to `Task` data model with three options: 
      - `once`: complete permanently after the first matching event in a campaign; do not listen for event in this task again
      - `count`: complete after ``event_count`` matching events; do not listen after N events occur for this task
      - `persistent`: reactivate after each matching event and remain open; listen indefinitely for this task
    - Adds event task reactivation to support `count` and `persistent` task event modes in `_should_reactivate_event_task` method of campaign orchestrator
    - Updates and new tests for task event mode checks

  Unique orchestrator queue names:
    - added queue suffix so we do not have conflicts of two orchestrators running on same broker, stealing each others messages
      - real use case: MBE was running campaigns on iHub orchestrator deployed on ORC; Neutrons was running a local orchestrator for debugging this branch for their campaign; campaigns on both got "hung" due to each having same queue names connected to same broker
    

  Other:
    - More logging for campaign orchestrator for debugging
    - Simplifying the Dockerfile + adds more explicit stuff to .dockerignore (to relax default ignore all by default later)
    - Adds lines for running unit tests without postgresql to README